### PR TITLE
✨ Allow Sequence fields to be Optional

### DIFF
--- a/src/schema/sequence.ts
+++ b/src/schema/sequence.ts
@@ -78,7 +78,7 @@ export const optionalTuple = (fields: SequenceFieldAry) =>
     return true;
   });
 
-export const sequence = <T extends SequenceFieldAry>(
+export const sequence = <const T extends SequenceFieldAry>(
   config: SequenceConfig<T>,
 ) => {
   const _tagClass = config?.tagClass ?? TagClass.UNIVERSAL;

--- a/src/schema/sequence.ts
+++ b/src/schema/sequence.ts
@@ -34,15 +34,10 @@ type SequenceAllFieldsTuple<T extends SequenceFieldAry> = {
   [P in keyof T]: [T[P]["name"], ReturnType<T[P]["schema"]["decode"]>];
 };
 
-type SequenceOptionalFieldsTuple<T extends SequenceFieldAry> = {
-  [P in keyof T as T[P] extends { optional: true } ? P : never]: [
-    T[P]["name"],
-    ReturnType<T[P]["schema"]["decode"]>,
-  ];
-};
-
-type SequenceOptionalFieldsNameTuple<T extends SequenceFieldAry> =
-  SequenceOptionalFieldsTuple<T>[keyof SequenceOptionalFieldsTuple<T>][0];
+type SequenceOptionalFieldsNameTuple<T extends SequenceFieldAry> = Extract<
+  T[number],
+  { optional: true }
+>["name"];
 
 type SequenceAllFieldsObjectType<T extends SequenceFieldAry> = TupleToObject<
   SequenceAllFieldsTuple<T>[number]

--- a/tests/schema/sequence.test.ts
+++ b/tests/schema/sequence.test.ts
@@ -26,7 +26,7 @@ describe("Sequence", () => {
           name: "message",
           schema: octetString(),
         },
-      ] as const,
+      ],
     });
 
     it("encode", () => {
@@ -65,7 +65,7 @@ describe("Sequence", () => {
           schema: octetString(),
           optional: true,
         },
-      ] as const,
+      ],
     });
 
     describe("Data contain optional fields", () => {

--- a/tests/schema/sequence.test.ts
+++ b/tests/schema/sequence.test.ts
@@ -5,6 +5,16 @@ import { octetString } from "../../src/schema/octet-string";
 import { sequence } from "../../src/schema/sequence";
 
 describe("Sequence", () => {
+  /**
+   * TODO: optionalTuple (v.special) の単体テスト
+   * - i[r], s[r] => OK
+   * - i[o], s[o] => OK
+   * - i[o], s[o, r] => NG (スキーマ残り)
+   * - i[r, o], s[o, r] => NG (インプット残り)
+   */
+  // describe("optionalTuple (SpecialValidation)", () => {
+  // })
+
   describe("default", () => {
     const schema = sequence({
       fields: [

--- a/tests/schema/sequence.test.ts
+++ b/tests/schema/sequence.test.ts
@@ -5,40 +5,107 @@ import { octetString } from "../../src/schema/octet-string";
 import { sequence } from "../../src/schema/sequence";
 
 describe("Sequence", () => {
-  const schema = sequence({
-    fields: [
-      {
-        name: "id",
-        schema: integer(),
-      },
-      {
-        name: "message",
-        schema: octetString(),
-      },
-    ] as const,
-  });
+  describe("default", () => {
+    const schema = sequence({
+      fields: [
+        {
+          name: "id",
+          schema: integer(),
+        },
+        {
+          name: "message",
+          schema: octetString(),
+        },
+      ] as const,
+    });
 
-  it("encode", () => {
-    expect(
-      Buffer.from(
-        schema.encode({
+    it("encode", () => {
+      expect(
+        Buffer.from(
+          schema.encode({
+            id: 50,
+            message: "hello",
+          }),
+        )
+          .toString("hex")
+          .toUpperCase(),
+      ).toEqual("300A020132040568656C6C6F");
+    });
+
+    it("decode", () => {
+      const result = schema.decode(
+        decodeAsn1(Buffer.from("300a020132040568656c6c6f", "hex")),
+      );
+
+      expect(result).toEqual({
+        id: 50,
+        message: "hello",
+      });
+    });
+  });
+  describe("optional", () => {
+    const schema = sequence({
+      fields: [
+        {
+          name: "id",
+          schema: integer(),
+        },
+        {
+          name: "message",
+          schema: octetString(),
+          optional: true,
+        },
+      ] as const,
+    });
+
+    describe("Data contain optional fields", () => {
+      it("encode", () => {
+        expect(
+          Buffer.from(
+            schema.encode({
+              id: 50,
+              message: "hello",
+            }),
+          )
+            .toString("hex")
+            .toUpperCase(),
+        ).toEqual("300A020132040568656C6C6F");
+      });
+
+      it("decode", () => {
+        const result = schema.decode(
+          decodeAsn1(Buffer.from("300a020132040568656c6c6f", "hex")),
+        );
+
+        expect(result).toEqual({
           id: 50,
           message: "hello",
-        }),
-      )
-        .toString("hex")
-        .toUpperCase(),
-    ).toEqual("300A020132040568656C6C6F");
-  });
+        });
+      });
+    });
 
-  it("decode", () => {
-    const result = schema.decode(
-      decodeAsn1(Buffer.from("300a020132040568656c6c6f", "hex")),
-    );
+    describe("Data does not contain optional fields", () => {
+      it("encode", () => {
+        expect(
+          Buffer.from(
+            schema.encode({
+              id: 50,
+            }),
+          )
+            .toString("hex")
+            .toUpperCase(),
+        ).toEqual("3003020132");
+      });
 
-    expect(result).toEqual({
-      id: 50,
-      message: "hello",
+      it("decode", () => {
+        const result = schema.decode(
+          decodeAsn1(Buffer.from("3003020132", "hex")),
+        );
+
+        expect(result).toEqual({
+          id: 50,
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
```typescript
const schema = sequence({
  fields: [
    {
      name: "id",
      schema: integer(),
    },
    {
      name: "message",
      schema: octetString(),
      // ✨ New option!
      optional: true,
    },
  ] as const,
});

const asn1Buf = schema.encode({
  // id: number
  id: 50,
  // message?: string | undefined
  message: "hello",
});

const result = schema.decode( /* Asn1Data */ );
const id = result.id; // number
const message = result.message; // string | undefined
```